### PR TITLE
Adapt to cucumber 2

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use 1.8.7-p352@cucumber-timed_formatter --create
+rvm use 2.2.3@cucumber-timed_formatter --create

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-source :rubygems
-
 gemspec
 
 group :development do

--- a/cucumber-timed_formatter.gemspec
+++ b/cucumber-timed_formatter.gemspec
@@ -4,7 +4,7 @@ require File.expand_path('../lib/cucumber-timed_formatter/version.rb', __FILE__)
 
 spec = Gem::Specification.new do |s|
   s.name = "cucumber-timed_formatter"
-  s.version = Cucumber::Formatter::Timed::VERSION
+  s.version = Cucumber::TimedFormatter::VERSION
   s.date = File.mtime(__FILE__)
   s.summary = "A progress-formatter with a little more info, instafailing."
   s.description = "A progress-formatter with a little more info: Each Scenario is one line and the time is measured. Additionally, errors are shown immediately to be a little like instafail.

--- a/cucumber-timed_formatter.gemspec
+++ b/cucumber-timed_formatter.gemspec
@@ -14,7 +14,6 @@ spec = Gem::Specification.new do |s|
   s.authors = ["Matthias Viehweger"]
   s.email = 'kronn@kronn.de'
   s.homepage = 'http://github.com/kronn/cucumber-timed_formatter'
-  s.rubyforge_project = '[none]' # to supress the warning
 
   s.require_paths = ["lib"]
   s.files = `git ls-files`.split("\n") - ['.gitignore']
@@ -24,7 +23,7 @@ spec = Gem::Specification.new do |s|
   s.rdoc_options = ['--charset=utf-8', '--all']
   # s.extra_rdoc_files = []
 
-  s.add_dependency 'cucumber', '~> 1.2'
+  s.add_dependency 'cucumber', '~> 2.0'
 
   # for release and doc generation, more less optional
   # s.add_development_dependency 'rake'

--- a/lib/cucumber-timed_formatter/version.rb
+++ b/lib/cucumber-timed_formatter/version.rb
@@ -1,7 +1,5 @@
 module Cucumber
-  module Formatter
-    class Timed
-      VERSION = '0.2.0'
-    end
+  module TimedFormatter
+    VERSION = '0.2.0'
   end
 end

--- a/lib/timed.rb
+++ b/lib/timed.rb
@@ -5,7 +5,7 @@ require 'cucumber/formatter/progress'
 require 'cucumber/cli/options'
 
 Cucumber::Cli::Options::BUILTIN_FORMATS['timed'] = [
-  "Cucumber::Formatter::Timed",
+  "Cucumber::Formatter::Timed",
   "A progress-formatter with a little more info, instafailing and line-wise output"
 ]
 
@@ -30,16 +30,17 @@ module Cucumber
         @duration += Time.now - @my_time
       end
 
-      def after_step_result(keyword, step_match, multiline_arg, status, exception, source_indent, background, *args)
-        super
-        if status == :failed
-          error_msg = "#{exception.message} (#{exception.class.name})\n#{exception.backtrace.join("\n")}"
+      def after_test_step(test_step, result)
+        super(test_step, result)
+
+        unless result.ok?
+          error_msg = "#{result.exception.message} (#{result.exception.class.name})\n#{result.exception.backtrace.join("\n")}"
 
           @io.puts <<-EOMESSAGE
 
-#{format_string(step_match.backtrace_line, :comment)}
+#{format_string(test_step.action_location, :comment)}
 
-#{format_string(error_msg, status)}
+#{format_string(error_msg, result.to_sym)}
 
           EOMESSAGE
         end

--- a/lib/timed.rb
+++ b/lib/timed.rb
@@ -31,7 +31,7 @@ module Cucumber
       end
 
       def after_test_step(test_step, result)
-        super(test_step, result)
+        super
 
         unless result.ok?
           error_msg = "#{result.exception.message} (#{result.exception.class.name})\n#{result.exception.backtrace.join("\n")}"


### PR DESCRIPTION
### Background

The gem was pinned down to cucumber 1.x and therefore not usable with cucumber 2.

### Changes

- Adapted to the changed `Progress` formatter
- Updated the .rvmrc with a more current Ruby :grinning: 
- Fixed the loading error because `Cucumber::Formatter::Timed` class was opened in two different files (Wonder how this worked back in Ruby 1.9 times?)

With these changes the gem works only with cucumber 2 and no longer with 1.x, which should be pointed in the Readme (which could need a overhaul anyway, same for the not existing license file :wink: )